### PR TITLE
[feature] An easy to use mail validator

### DIFF
--- a/api/utils/mail_validator.js
+++ b/api/utils/mail_validator.js
@@ -1,0 +1,26 @@
+const Joi = require('@hapi/joi');
+const schema = require('./mail_validator.model');
+
+
+const schemaValidator = (object, type) => {
+  return new Promise((resolve, reject) => {
+    if (!object) {
+      reject(new Error('object to validate not provided'));
+    }
+    if (!type) {
+      reject(new Error('schema type to validate not provided'));
+    }
+
+    const {error, value} = schema[type](Joi).validate(object);
+
+    if (error) {
+      reject(new Error(`invalid ${type} data, error: ${error}`));
+    }
+    resolve(value);
+  });
+};
+
+module.exports = Object.create({
+  validate: schemaValidator,
+  schema
+});

--- a/api/utils/mail_validator.js
+++ b/api/utils/mail_validator.js
@@ -14,7 +14,7 @@ const schemaValidator = (object, type) => {
     const {error, value} = schema[type](Joi).validate(object);
 
     if (error) {
-      reject(new Error(`invalid ${type} data, error: ${error}`));
+      reject(new Error(`Invalid ${type} data, ${error}`));
     }
     resolve(value);
   });

--- a/api/utils/mail_validator.model.js
+++ b/api/utils/mail_validator.model.js
@@ -2,27 +2,29 @@ const sendMailSchema = (Joi) => Joi.object({
   from: Joi.string().required(),
   recipient: Joi.string().email().required(),
   cc: Joi.array()
-    .items(Joi.string().email()) .sparse(),
+    .items(Joi.string().email()).sparse(),
 
   bcc: Joi.array()
-    .items(Joi.string().email()) .sparse(),
+    .items(Joi.string().email()).sparse(),
 
-  subject: Joi.string(),
+  subject: Joi.string().required(),
   text: Joi.string().required()
 });
 
 const sendMailWithTemplateSchema = (Joi) => Joi.object({
-  from: Joi.string().required(),
+  from: Joi.string().required().required(),
   recipient: Joi.string().email().required(),
   bcc: Joi.array()
     .items(Joi.string().email()).sparse(),
+    
+  cc: Joi.array()
+    .items(Joi.string().email()).sparse(),
 
-  subject: Joi.string(),
-  html: Joi.string()
+  subject: Joi.string().required(),
+  html: Joi.string().required()
 });
 
 module.exports = {
   sendmail : sendMailSchema,
   sendmailwithtemplate: sendMailWithTemplateSchema
 };
-

--- a/api/utils/mail_validator.model.js
+++ b/api/utils/mail_validator.model.js
@@ -1,0 +1,28 @@
+const sendMailSchema = (Joi) => Joi.object({
+  from: Joi.string().required(),
+  recipient: Joi.string().email().required(),
+  cc: Joi.array()
+    .items(Joi.string().email()) .sparse(),
+
+  bcc: Joi.array()
+    .items(Joi.string().email()) .sparse(),
+
+  subject: Joi.string(),
+  text: Joi.string().required()
+});
+
+const sendMailWithTemplateSchema = (Joi) => Joi.object({
+  from: Joi.string().required(),
+  recipient: Joi.string().email().required(),
+  bcc: Joi.array()
+    .items(Joi.string().email()).sparse(),
+
+  subject: Joi.string(),
+  html: Joi.string()
+});
+
+module.exports = {
+  sendmail : sendMailSchema,
+  sendmailwithtemplate: sendMailWithTemplateSchema
+};
+

--- a/api/utils/mail_validator.spec.js
+++ b/api/utils/mail_validator.spec.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const {validate} = require('./mail_validator'); 
+
+console.log(Object.getPrototypeOf(validate))
+
+describe('Schemas Validation', () => {
+  
+  it('can validate a mail object', (done) => {
+    const samplemail = {
+      from: 'Noreply <Joedegs@gmail.com>',
+      recipient: 'jpedegs8990@gmail.com',
+      cc: ['kojiis@gmail.com', 'Joeiejr@ymail.com'],
+      bcc: [],
+      subject: 'subject of the motherfucking email',
+      text: 'Body of the email'
+    }
+    
+    validate(samplemail, 'sendmail')
+      .then(value => {
+        assert.ok(value);
+        done()
+      })
+      .catch(err => {
+        console.log(err)
+        done()
+      });
+  });
+
+  it('it can validate a mail object with template', (done) => {
+    const sampleMailWithTemplate = {
+      from: 'Test testorisis <noreply@testorisin.com>',
+      recipient: 'npedev3443@tmail.com',
+      bcc: ['something@smail.com', 'teamfierce@fmail.com'],
+      subject: 'This test must PASS',
+      html: `
+      <h1> A TEST SAMPLE </h1>
+
+      <p> The html body <p><br>
+
+      <h3> ENJOY THIS TEST BYE... </h3>
+      `
+    };
+
+    validate(sampleMailWithTemplate, 'sendmailwithtemplate')
+      .then(value => {
+        assert.ok(value);
+        done();
+      })
+      .catch(err => {
+        console.log(err);
+        done();
+      });
+  });
+
+  it('return error if email address is not valid', (done) => {
+    const sampleMail = {
+      from: 'noreply@smap.comd',
+      recipient: 'teamfierce.com', //invalid email address
+      subject: 'Subject of mail',
+      body: 'some random text'
+    }
+
+    validate(sampleMail, 'sendmail')
+      .then(value => {
+        assert.ok(!value);
+        done()
+      })
+      .catch(err => {
+        assert.ok(err);
+        done();
+      })
+  });
+
+});
+

--- a/api/utils/mail_validator.spec.js
+++ b/api/utils/mail_validator.spec.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+
 const assert = require('assert');
 const {validate} = require('./mail_validator'); 
 
@@ -62,13 +64,33 @@ describe('Schemas Validation', () => {
 
     validate(sampleMail, 'sendmail')
       .then(value => {
-        assert.ok(!value);
-        done()
+		console.log(value);
       })
       .catch(err => {
         assert.ok(err);
         done();
       })
+  });
+  
+  it('test required fields', (done) => {
+  	const faultyMail = {
+  	  from: 'somebody.mail.com',
+  	  recipient: 'email@add.com',
+  	  subject: '',	// cannot be empty
+  	  body: ''
+  	}
+  	
+  	validate(faultyMail, 'sendmail')
+  	  .then(value => {
+  	    //console.log(value);
+  	    assert.ok(value);
+  	    done();
+  	  })
+  	  .catch(err => {
+  	    //console.log(err);
+  	    assert.ok(err)
+  	    done();
+  	  });
   });
 
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,49 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@hapi/address": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npm.taobao.org/@hapi/address/download/@hapi/address-4.0.1.tgz",
+      "integrity": "sha1-JnMB3fe8RTcYN3pvs4MqLwSnId0=",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/@hapi/formula/download/@hapi/formula-2.0.0.tgz",
+      "integrity": "sha1-7a3gYZ7VjI5PFk8jPNpwIR54cSg="
+    },
+    "@hapi/hoek": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npm.taobao.org/@hapi/hoek/download/@hapi/hoek-9.0.4.tgz",
+      "integrity": "sha1-6ArU6OjSrcbHfZhfaYRH6GKLYBA="
+    },
+    "@hapi/joi": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npm.taobao.org/@hapi/joi/download/@hapi/joi-17.1.1.tgz",
+      "integrity": "sha1-nMjX4sIhPR5GcIxiYBhLRHxmE1A=",
+      "requires": {
+        "@hapi/address": "^4.0.1",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/@hapi/pinpoint/download/@hapi/pinpoint-2.0.0.tgz",
+      "integrity": "sha1-gFtA1NvsBPwRanMIlJTgDwc96N8="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npm.taobao.org/@hapi/topo/download/@hapi/topo-5.0.0.tgz",
+      "integrity": "sha1-wZr4V3+jk6BunHe2CZWvlZvnIec=",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/lollykrown/Team-fierce-mailing-API#readme",
   "dependencies": {
+    "@hapi/joi": "^17.1.1",
     "body-parser": "^1.19.0",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
This feature introduces a way to seamlessly validate the mail about to be sent and it is also promised based which means it is unblocking

Using this is extremely simple, you just import the `mail_validator.js` file inside the utils folder, this file when imported returns an object with two things
- a validator function: the function that coordinates the mail object validation
- schema table: that contains the schema functions that do the actual validation of the mail objects

It is extremely easy to use and structured in a way you don't have to think about the implementation to use it.

The validator function takes two parameters, a mail object to validate and the route on which you are validating. We have two routes, so that will be either a `sendmail` or `sendmailwithtemplate` option.
```
validator([mailObject -> Object], [route -> 'sendmail' | 'sendmailwithtemplate'])
```

The validator is promised based, so if you call it either 
- resolves  a `value` object that contains all the mail objects that have undergone the validation
- or rejects with an `error` object containing the specific reason it failed
 
A simple way to use this will be 

```js
const { validate } = require('./utils/mail_validator');

const samplemail = {
      from: 'Noreply <Joedegs@gmail.com>',
      recipient: 'jpedegs8990@gmail.com',
      cc: ['kojiis@gmail.com', 'Joeiejr@ymail.com'],
      bcc: [],
      subject: 'subject of the motherfucking email',
      text: 'Body of the email'
}

validate(samplemail, 'sendmail')
    .then(console.log).catch(console.log);
```

slackName: Joe.Attah
Team Fierce.